### PR TITLE
Fix compile.

### DIFF
--- a/combinators.lisp
+++ b/combinators.lisp
@@ -74,10 +74,10 @@
     `(funcall ,kind ,first (parser* ,kind ,(car remaining) ,@(cdr remaining)))))
 
 (defmacro or-parser* (first &rest remaining)
-  `(parser* ,#'or-parser ,first ,@remaining))
+  `(parser* #'or-parser ,first ,@remaining))
 
 (defmacro and-parser* (first &rest remaining)
-  `(parser* ,#'and-parser ,first ,@remaining))
+  `(parser* #'and-parser ,first ,@remaining))
 	       
 (defun make-sentence (np vp)
   (list 'sentence np vp))


### PR DESCRIPTION
Long story short, macros should expand to source code forms.  The
OR-PARSER* and AND-PARSER* macros were evaluating function forms at compile
time (i.e. ,#'or-parser within the macro).  Since #'or-parser is evaluates
to something like #<function OR-PARSER> the compiler refuses to place it in
the .fasl.